### PR TITLE
[accenv] defaultRunner() par défaut, disparition <device-affinity>

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,9 +11,9 @@ find_package(Arcane)
 # Indique la version minimale de Arcane nécessaire
 # À partir de la version 3.8 de Arcane, il sera possible
 # d'utiliser directement 'find_package(Arcane 3.8 REQUIRED)'
-if (Arcane_VERSION VERSION_LESS "3.6")
+if (Arcane_VERSION VERSION_LESS "3.9")
   message(FATAL_ERROR "Arcane version '${Arcane_VERSION}' is too old."
-    " Version 3.6+ is required")
+    " Version 3.9+ is required")
 endif()
 
 if (WANT_CUDA AND NOT ARCANE_HAS_CUDA)

--- a/src/accenv/AccEnvDefault.axl
+++ b/src/accenv/AccEnvDefault.axl
@@ -17,15 +17,6 @@
   <!-- - - - - - acc-mem-advise - - - - -->
   <simple name="acc-mem-advise" type="bool" default="true"><description>Active/désactive tous les conseils mémoire (ie tous les appels à cudaMemAdvise).</description></simple>
 
-  <!-- - - - - device-affinity - - - - -->
-  <enumeration name="device-affinity" type="eDeviceAffinity" default="node_rank">
-    <description>Manière de choisir le device attaché au processus</description>
-    <enumvalue name="none" genvalue="DA_none" />
-    <enumvalue name="world_rank" genvalue="DA_world_rank" />
-    <enumvalue name="node_rank" genvalue="DA_node_rank" />
-    <!-- <enumvalue name="cu_hwloc" genvalue="DA_cu_hwloc" /> -->
-  </enumeration>
-
   <!-- - - - - heterog-partition - - - - -->
   <enumeration name="heterog-partition" type="eHeterogPartition" default="none">
     <description>Manière de répartir Host/Device sur les sous-domaines</description>

--- a/src/accenv/AccEnvDefaultOptions.h
+++ b/src/accenv/AccEnvDefaultOptions.h
@@ -1,15 +1,6 @@
 #ifndef ACC_ENV_DEFAULT_OPTIONS_H
 #define ACC_ENV_DEFAULT_OPTIONS_H
 
-/*! \brief Manière de choisir le device attaché au processus
- */
-enum eDeviceAffinity {
-  DA_none = 0,      //! Aucune sélection de device
-  DA_world_rank,    //! device = world_rank%device_count
-  DA_node_rank,     //! device =  node_rank%device_count
-  DA_cu_hwloc       //! cherche à placer sur le device le plus proche (si hwloc détecté)
-};
-
 /*! \brief Manière de répartir Host/Device sur les sous-domaines
  */
 enum eHeterogPartition {

--- a/src/accenv/AccEnvDefaultService.cc
+++ b/src/accenv/AccEnvDefaultService.cc
@@ -4,57 +4,7 @@
 #include <arcane/IParallelMng.h>
 #include <arcane/ParallelMngUtils.h>
 #include <arcane/IParallelTopology.h>
-
-#if defined(ACCENV_HWLOC) && defined(ARCANE_COMPILING_CUDA)
-#warning "HWLOC présent pour placement GPUs"
-// Code issu de https://www.open-mpi.org/faq/?category=runcuda
-#include <cuda.h>
-#include <mpi.h>
-#include <hwloc.h>
-
-#define ABORT_ON_ERROR(func)                          \
-  { CUresult res;                                     \
-    res = func;                                       \
-    if (CUDA_SUCCESS != res) {                        \
-        printf("%s returned error=%d\n", #func, res); \
-        abort();                                      \
-    }                                                 \
-  }
-
-#define ABORT_ON_HWLOC_ERROR(func)                    \
-  { int res;                                          \
-    res = func;                                       \
-    if (0 != res) {                                   \
-        printf("%s returned error=%d\n", #func, res); \
-        abort();                                      \
-    }                                                 \
-  }
-
-/**
- * This function searches for all the GPUs that are hanging off a NUMA
- * node.  It walks through each of the PCI devices and looks for ones
- * with the NVIDIA vendor ID.  It then stores them into an array.
- * Note that there can be more than one GPU on the NUMA node.
- */
- 
-void find_gpus(hwloc_topology_t topology, hwloc_obj_t parent, hwloc_obj_t child,
-    int* gpuIndex, hwloc_obj_t gpus[]) {
-  hwloc_obj_t pcidev;
-  pcidev = hwloc_get_next_child(topology, parent, child);
-  if (NULL == pcidev) {
-    return;
-  } else if (0 != pcidev->arity) {
-    /* This device has children so need to look recursively at them */
-    find_gpus(topology, pcidev, NULL, gpuIndex, gpus);
-    find_gpus(topology, parent, pcidev, gpuIndex, gpus);
-  } else {
-    if (pcidev->attr->pcidev.vendor_id == 0x10de) {
-      gpus[(*gpuIndex)++] = pcidev;
-    }
-    find_gpus(topology, parent, pcidev, gpuIndex, gpus);
-  }
-}
-#endif
+#include <arcane/accelerator/core/IAcceleratorMng.h>
 
 using namespace Arcane;
 
@@ -82,10 +32,9 @@ void AccEnvDefaultService::
 initAcc()
 {
   info() << "Using accelerator";
-  IApplication* app = subDomain()->application();
   if (options()->getHeterogPartition() == HP_none) 
   {
-    initializeRunner(m_runner,traceMng(),app->acceleratorRuntimeInitialisationInfo());
+    m_runner_ptr = subDomain()->acceleratorMng()->defaultRunner();
   }
   else if (options()->getHeterogPartition() == HP_heterog1)
   {
@@ -96,126 +45,22 @@ initAcc()
       ostr << "(Host) P=" << mesh()->parallelMng()->commRank();
       if (TaskFactory::isActive()) {
         ostr << " using Task runtime";
-        m_runner.initialize(ax::eExecutionPolicy::Thread);
+        m_host_runner.initialize(ax::eExecutionPolicy::Thread);
       } else {
         ostr << " using Sequential runtime";
-        m_runner.initialize(ax::eExecutionPolicy::Sequential);
+        m_host_runner.initialize(ax::eExecutionPolicy::Sequential);
       }
       pinfo() << ostr.str();
+      m_runner_ptr = &m_host_runner;
     } else {
       // Initialisation classique : accelerateur ou pas
-      initializeRunner(m_runner,traceMng(),app->acceleratorRuntimeInitialisationInfo());
+      m_runner_ptr = subDomain()->acceleratorMng()->defaultRunner();
     }
   }
-
-  bool is_acc_av = AcceleratorUtils::isAvailable(m_runner);
-  if (is_acc_av && options()->getDeviceAffinity() == DA_world_rank) 
+  else
   {
-    info() << "Placement GPU : device =  world_rank%device_count";
-
-    Integer device_count = AcceleratorUtils::deviceCount();
-    if (device_count>0) {
-      Integer rank = mesh()->parallelMng()->commRank();
-      Integer device=rank%device_count;
-      AcceleratorUtils::setDevice(device);
-      pinfo() << "Processus " << rank  
-        << " : Device " << device << " (pour " << device_count << " device(s))";
-    }
+    m_runner_ptr = subDomain()->acceleratorMng()->defaultRunner();
   }
-  if (options()->getDeviceAffinity() == DA_node_rank) 
-  {
-    IParallelMng* pm = mesh()->parallelMng();
-    // Attention, createTopology() est une opération collective
-    Ref<IParallelTopology> pt = ParallelMngUtils::createTopologyRef(pm);
-    auto node_ranks = pt->machineRanks();
-    // Attention, createSubParallelMng() est une opération collective
-    Ref<IParallelMng> pm_node = pm->createSubParallelMngRef(node_ranks);
-
-    if (is_acc_av) {
-      info() << "Placement GPU : device =  node_rank%device_count";
-
-      Integer device_count = AcceleratorUtils::deviceCount();
-      if (device_count>0) {
-        Integer rank = pm->commRank();
-        Integer node_rank = pm_node->commRank();
-        Integer device=node_rank%device_count;
-        AcceleratorUtils::setDevice(device);
-        pinfo() << "Processus " << rank  << " (node_rank=" << node_rank << ")"
-          << " : Device " << device << " (pour " << device_count << " device(s))";
-      }
-    }
-  }
-#ifdef ARCANE_COMPILING_CUDA
-#ifdef ACCENV_HWLOC
-  if (is_acc_av && options()->getDeviceAffinity() == DA_cu_hwloc) 
-  {
-    info() << "Placement GPU avec hwloc";
-    // Code issu de https://www.open-mpi.org/faq/?category=runcuda
-    //
-#if 0
-    const unsigned long flags = HWLOC_TOPOLOGY_FLAG_IO_DEVICES | HWLOC_TOPOLOGY_FLAG_IO_BRIDGES;
-#endif
-    hwloc_cpuset_t newset;
-    hwloc_obj_t node, bridge;
-    char pciBusId[16];
-    CUdevice dev;
-    char devName[256];
-    hwloc_topology_t topology = NULL;
-    int gpuIndex = 0;
-    hwloc_obj_t gpus[16] = {0};
-
-    /* Now decide which GPU to pick.  This requires hwloc to work properly.
-     * We first see which CPU we are bound to, then try and find a GPU nearby.
-     */
-    ABORT_ON_HWLOC_ERROR( hwloc_topology_init(&topology) );
-#if 0
-    ABORT_ON_HWLOC_ERROR( hwloc_topology_set_flags(topology, flags) );
-#else
-    ABORT_ON_HWLOC_ERROR( hwloc_topology_set_io_types_filter(topology, HWLOC_TYPE_FILTER_KEEP_IMPORTANT) );
-#endif
-    ABORT_ON_HWLOC_ERROR( hwloc_topology_load(topology) );
-    newset = hwloc_bitmap_alloc();
-    ABORT_ON_HWLOC_ERROR( hwloc_get_last_cpu_location(topology, newset, 0) );
-
-    /* Get the object that contains the cpuset */
-    node = hwloc_get_first_largest_obj_inside_cpuset(topology, newset);
-
-    /* Climb up from that object until we find the HWLOC_OBJ_NODE */
-    while (node->type != HWLOC_OBJ_NODE) {
-      node = node->parent;
-    }
-
-    /* Now look for the HWLOC_OBJ_BRIDGE.  All PCI busses hanging off the
-     * node will have one of these */
-    bridge = hwloc_get_next_child(topology, node, NULL);
-    while (bridge->type != HWLOC_OBJ_BRIDGE) {
-      bridge = hwloc_get_next_child(topology, node, bridge);
-    }
-
-    /* Now find all the GPUs on this NUMA node and put them into an array */
-    find_gpus(topology, bridge, NULL, &gpuIndex, gpus);
-
-    /* Now select the first GPU that we find */
-    if (gpus[0] == 0) {
-      printf("No GPU found\n");
-      exit(1);
-    } else {
-      sprintf(pciBusId, "%.2x:%.2x:%.2x.%x", gpus[0]->attr->pcidev.domain, gpus[0]->attr->pcidev.bus,
-          gpus[0]->attr->pcidev.dev, gpus[0]->attr->pcidev.func);
-      ABORT_ON_ERROR(cuDeviceGetByPCIBusId(&dev, pciBusId));
-      ABORT_ON_ERROR(cuDeviceGetName(devName, 256, dev));
-
-      // Affichage
-      Integer device, device_count;
-      cudaGetDevice(&device_count);
-      cudaGetDevice(&device);
-      pinfo() << "Processus " << mesh()->parallelMng()->commRank()
-        << " : Device " << device << " (pour " << device_count << " device(s))"
-        << " (Selected GPU=" << pciBusId << ", name=" << devName << ")";
-    }
-  }
-#endif // ACCENV_HWLOC
-#endif // ARCANE_COMPILING_CUDA
 }
 
 /*---------------------------------------------------------------------------*/
@@ -223,7 +68,7 @@ initAcc()
 /*---------------------------------------------------------------------------*/
 Ref<ax::RunQueue> AccEnvDefaultService::
 refQueueAsync(eQueuePriority qp) {
-  return AcceleratorUtils::refQueueAsync(m_runner, qp);
+  return AcceleratorUtils::refQueueAsync(runner(), qp);
 }
 
 /*---------------------------------------------------------------------------*/
@@ -289,7 +134,7 @@ initMesh(IMesh* mesh)
   m_acc_mem_adv->setReadMostly(allFaces().view().localIds());
   m_acc_mem_adv->setReadMostly(ownFaces().view().localIds());
 
-  m_vsync_mng = new VarSyncMng(mesh, m_runner, m_acc_mem_adv);
+  m_vsync_mng = new VarSyncMng(mesh, runner(), m_acc_mem_adv);
   m_vsync_mng->setDefaultVarSyncVersion(options()->getVarSyncVersion());
 }
 

--- a/src/accenv/AccEnvDefaultService.h
+++ b/src/accenv/AccEnvDefaultService.h
@@ -22,8 +22,8 @@ class AccEnvDefaultService : public ArcaneAccEnvDefaultObject
  public:
   void initAcc() override;
 
-  ax::Runner& runner() override { return m_runner; }
-  ax::RunQueue newQueue() override { return makeQueue(m_runner); }
+  ax::Runner& runner() override { return *m_runner_ptr; }
+  ax::RunQueue newQueue() override { return makeQueue(*m_runner_ptr); }
   Ref<ax::RunQueue> refQueueAsync(eQueuePriority qp=QP_default) override;
 
   AccMemAdviser* accMemAdv() override { return m_acc_mem_adv; }
@@ -48,7 +48,8 @@ class AccEnvDefaultService : public ArcaneAccEnvDefaultObject
   void _computeNodeIndexInCells();
 
  protected:
-  ax::Runner m_runner;
+  ax::Runner m_host_runner;
+  ax::Runner* m_runner_ptr=nullptr;
   AccMemAdviser* m_acc_mem_adv=nullptr;
   UnstructuredMeshConnectivityView m_connectivity_view;
 

--- a/src/accenv/AcceleratorUtils.h
+++ b/src/accenv/AcceleratorUtils.h
@@ -114,30 +114,6 @@ class AcceleratorUtils {
     return ax::impl::isAcceleratorPolicy(runner.executionPolicy());
   }
 
-  static Integer deviceCount() {
-#if defined(ARCANE_COMPILING_CUDA)
-    Integer device_count=0;
-    cudaGetDeviceCount(&device_count);
-    return device_count;
-#elif defined(ARCANE_COMPILING_HIP)
-    Integer device_count=0;
-    auto err = hipGetDeviceCount(&device_count);
-    return device_count;
-#else
-    return 0;
-#endif
-  }
-
-  static void setDevice([[maybe_unused]] Integer device) {
-#if defined(ARCANE_COMPILING_CUDA)
-    cudaSetDevice(device);
-#elif defined(ARCANE_COMPILING_HIP)
-    auto err = hipSetDevice(device);
-#else
-    return ;
-#endif
-  }
-
   /*---------------------------------------------------------------------------*/
   /* Référence sur une queue asynchrone créée avec un niveau de priorité       */
   /*---------------------------------------------------------------------------*/


### PR DESCRIPTION
Le binding processus-GPU doit s'effectuer soit :
 - par le wrapper bin/wrapper_mgpu.bash
 - ou bien par la var env ARCANE_ACCELERATOR_PARALLELMNG_RANK_FOR_DEVICE=<nGPUs_per_node>